### PR TITLE
Line wrapping length is set in the tidy config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ BUILDDIR ?= build
 REPOS = https://github.com/w3c/respec|gh-pages https://github.com/dontcallmedom/webidl-checker https://github.com/dontcallmedom/widlproc https://github.com/dontcallmedom/linkchecker https://github.com/htacg/tidy-html5
 TIDYCONF ?= $(firstword $(wildcard tidy.config webrtc-respec-ci/tidy.config))
 LINEWRAP ?= false
+LINEWRAPLENGTH = $(shell cat $(TIDYCONF) | grep "^wrap:" | cut -f 2 -d ' ')
 
 ifndef TIDY
 TIDY = $(SUPPORTDIR)/tidy-html5/build/cmake/tidy


### PR DESCRIPTION
This setting is now configured in tidy.config
The LINEWRAPLENGTH var now only serves to display a meaningful message.